### PR TITLE
ci: cap job runtime and bound the apt step

### DIFF
--- a/.github/workflows/render-module-rmd.yaml
+++ b/.github/workflows/render-module-rmd.yaml
@@ -21,6 +21,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[skip-ci]')"
     name: Render module Rmd
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.4
 
       - name: Install other dependencies
         run: |
@@ -61,13 +62,13 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-Require@v0.2
+      - uses: PredictiveEcology/actions/install-Require@v0.4
         with:
           GitTag: 'development'
 
-      - uses: PredictiveEcology/actions/install-SpaDES@v0.2
+      - uses: PredictiveEcology/actions/install-SpaDES@v0.4
 
-      - uses: PredictiveEcology/actions/install-Rmd-pkgs@v0.2
+      - uses: PredictiveEcology/actions/install-Rmd-pkgs@v0.4
 
       - name: Install module package and other dependencies
         run: |


### PR DESCRIPTION
### Why

The render workflow sets no `timeout-minutes`, so a stalled step runs to GitHub's **6 hour** default before failing.

That is not hypothetical. On 2026-08-19 two jobs in a sibling repo using the same `install-spatial-deps` action sat in that step for **6h0m** and were killed, while the `ubuntugis` PPA was transiently unhealthy. Every other ubuntu job in the same matrix was degraded too (one took 56m against its usual ~8m). Re-running the identical commit passed all jobs in 6–9 minutes — so nothing was wrong with the package, but it cost 12 runner-hours and presented as a package failure.

### What

- **`timeout-minutes: 90` on the job** — a stall now fails in minutes rather than hours. 90 rather than something tighter because these render jobs build a large dependency tree from source.
- **`PredictiveEcology/actions` pinned `v0.2` → `v0.4`**, which:
  - wraps each apt call in `timeout` (5m/5m/10m) with 3 attempts and backoff — composite-action steps do *not* support `timeout-minutes`, so this is the only way to bound them from inside;
  - sets `DEBIAN_FRONTEND=noninteractive` (with `sudo -E`) so an unattended `apt-get` cannot block on a debconf prompt;
  - passes `--no-install-recommends`.

`install-spatial-deps` is the **only** action changed between `v0.2` and `v0.4`, so the pin bump carries nothing else.

### Scope

Workflow file only — no module code touched. Branched from `development` so the diff is this change alone.